### PR TITLE
Fix site ordering for mixed multi-site Gate application

### DIFF
--- a/src/Mixer.jl
+++ b/src/Mixer.jl
@@ -107,7 +107,7 @@ function tensor(a::Left, site::AbstractSite...)
     js = sim.(is)
     ci = combinerto(i, reverse(is)...)
     cj = combinerto(j, reverse(js)...)
-    ijs = Iterators.flatten(zip(is, js))
+    ijs = Iterators.flatten(zip(reverse(is), reverse(js)))
     c = combiner(ijs...; tags="")
     return (ti * ci * ci') * (delta(j, j') * cj * cj') * c * c'
 end
@@ -120,7 +120,7 @@ function tensor(a::Right, site::AbstractSite...)
     js = sim.(is)
     ci = combinerto(i, reverse(is)...)
     cj = combinerto(j, reverse(js)...)
-    jis = Iterators.flatten(zip(js, is))
+    jis = Iterators.flatten(zip(reverse(js), reverse(is)))
     c = combiner(jis...; tags="")
     return (delta(j, j') * cj * cj') * (dag(ti) * ci * ci') * c * c'
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,6 +302,25 @@ end
                 ]
             )
         ])
+        @test_ok begin
+            sys = System(2, Qubit())
+            ux2 = Operator{2}(
+                "UX2",
+                [
+                    0. 1. 0. 0.;
+                    1. 0. 0. 0.;
+                    0. 0. 0. 1.;
+                    0. 0. 1. 0.;
+                ],
+                plain_op,
+            )
+            psi = State{Pure}(sys, "0")
+            rho_from_pure = mix(apply(ux2(1, 2), psi))
+            rho_direct = apply(ux2(1, 2), mix(psi))
+
+            @test expect(rho_from_pure, Z(1)) ≈ expect(rho_direct, Z(1))
+            @test expect(rho_from_pure, Z(2)) ≈ expect(rho_direct, Z(2))
+        end
     end
     @testset "Steady state" begin
         @test_ok test_phases([


### PR DESCRIPTION
This fixes an inconsistency between pure-state and mixed-state application of generic multi-site gates.

For a generic two-qubit matrix gate `U` and a pure state `psi`, the two expressions

```julia
mix(apply(U(1, 2), psi))
```

and

```julia
apply(U(1, 2), mix(psi))
```

should represent the same density matrix. Before this change, they could give different results: in the mixed-state path, the ordering of the local sites was effectively reversed for generic two-site gates. For example, a gate intended to act differently on sites 1 and 2 could produce observables with the two site roles exchanged after conversion to the mixed representation.

This PR fixes that ordering by interleaving the reversed local index lists in the final combiners for both the left and right mixed gate actions. With this change, direct mixed-state gate application is consistent with applying the same gate to a pure state and then calling `mix`.

A regression test has also been added to `test/runtests.jl` in the `"Noisy gates"` testset. The test uses a two-site gate whose action is asymmetric between the two qubits and compares the two paths

```julia
rho_from_pure = mix(apply(U(1, 2), psi))
rho_direct = apply(U(1, 2), mix(psi))
```

by checking local observables on both sites. This test fails with the previous site-ordering behavior and passes with the fix.